### PR TITLE
Metrics endpoint

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -33,6 +33,12 @@ plans:
         type: string
         required: False
         title: Sync Application health endpoint
+      - name: SYNC_APP_METRICS_ENDPOINT
+        description: Metrics endpoint of your Sync Application (using '/metrics' if not specified)
+        type: string
+        required: False
+        title: Sync Application metrics endpoint
+        default: 'metrics'
       - name: SYNC_APP_PORT
         description: Port of the Sync Application to Expose
         type: number

--- a/roles/provision-sync-app-apb/defaults/main.yml
+++ b/roles/provision-sync-app-apb/defaults/main.yml
@@ -1,6 +1,7 @@
 sync_app_docker_image: "{{ SYNC_APP_DOCKER_IMAGE }}"
 sync_app_docker_image_version: "{{ SYNC_APP_DOCKER_IMAGE_VERSION | default('latest', true) }}"
 sync_app_health_endpoint: "{{ SYNC_APP_HEALTH_ENDPOINT | default('', true) }}"
+sync_app_metrics_endpoint: "{{ SYNC_APP_METRICS_ENDPOINT | default('metrics', true) }}"
 sync_app_graphql_endpoint: "{{ SYNC_APP_GRAPHQL_ENDPOINT | default('graphql', true) }}"
 
 

--- a/roles/provision-sync-app-apb/tasks/main.yml
+++ b/roles/provision-sync-app-apb/tasks/main.yml
@@ -12,6 +12,8 @@
     spec_template_metadata_labels:
       app: sync-app
       service: sync-app
+    spec_template_metadata_annotations:
+      org.aerogear.metrics/plain_endpoint: '{{ sync_app_metrics_endpoint }}'
     triggers:
     - imageChangeParams:
         automatic: true
@@ -27,6 +29,9 @@
     - name: sync-app
       image: '{{ sync_app_docker_image }}:{{ sync_app_docker_image_version }}'
       imagePullPolicy: Always
+      ports:
+        - containerPort: '{{ SYNC_APP_PORT }}'
+          protocol: "TCP"
       readinessProbe:
         httpGet:
           path: '/{{ sync_app_health_endpoint }}'

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -3,6 +3,7 @@
 sync_app_docker_image: "docker.io/aerogear/voyager-server-example-task"
 sync_app_docker_image_version: "latest"
 sync_app_health_endpoint: ""
+sync_app_metrics_endpoint: "metrics"
 sync_app_graphql_endpoint: "graphql"
 SYNC_APP_PORT: 3000
 DB_HOSTNAME: "db.example.com"


### PR DESCRIPTION
Changes:
1. Specified the container port, so that Prometheus is able to pick it up and use it instead of the default 80
2. Metrics endpoint annotation is now added