### PR TITLE
AEROGEAR-8515 - Client info graphs in sync dashboard

### DIFF
--- a/roles/provision-sync-app-apb/templates/sync-dashboard.json.j2
+++ b/roles/provision-sync-app-apb/templates/sync-dashboard.json.j2
@@ -19,38 +19,12 @@
   "links": [],
   "panels": [
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 6,
-      "panels": [],
-      "title": "Client",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 4,
-      "panels": [],
-      "title": "Server",
-      "type": "row"
-    },
-    {
       "content": "# Data Synchronization\n\nSync mobile data synchronization framework allows Sync Apps to seamessly continue working when the network conection is lost, and allows them to recover when the network connection is restored.\n\nFind out more at [docs.aerogear.org](https://docs.aerogear.org/aerogear/latest/data_sync.html)!",
       "gridPos": {
         "h": 4,
         "w": 14,
         "x": 0,
-        "y": 2
+        "y": 0
       },
       "id": 35,
       "links": [],
@@ -82,7 +56,7 @@
         "h": 4,
         "w": 5,
         "x": 14,
-        "y": 2
+        "y": 0
       },
       "id": 34,
       "interval": null,
@@ -169,7 +143,7 @@
         "h": 4,
         "w": 5,
         "x": 19,
-        "y": 2
+        "y": 0
       },
       "id": 36,
       "interval": null,
@@ -235,6 +209,200 @@
       "valueName": "avg"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Client",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count( count by (client_id) (clients) )",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Unique clients",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unique clients over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 39,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count( count by (user_id) (users) )",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Unique users",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unique users over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Server",
+      "type": "row"
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -258,7 +426,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 6
+        "y": 15
       },
       "hideTimeOverride": true,
       "id": 14,
@@ -332,7 +500,7 @@
         "h": 7,
         "w": 20,
         "x": 4,
-        "y": 6
+        "y": 15
       },
       "hideTimeOverride": false,
       "id": 16,
@@ -449,7 +617,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 13
+        "y": 22
       },
       "hideTimeOverride": true,
       "id": 18,
@@ -520,7 +688,7 @@
         "h": 7,
         "w": 20,
         "x": 4,
-        "y": 13
+        "y": 22
       },
       "hideTimeOverride": false,
       "id": 19,
@@ -625,7 +793,7 @@
         "h": 6,
         "w": 9,
         "x": 0,
-        "y": 20
+        "y": 29
       },
       "hideTimeOverride": false,
       "id": 24,
@@ -726,7 +894,7 @@
         "h": 6,
         "w": 7,
         "x": 9,
-        "y": 20
+        "y": 29
       },
       "hideTimeOverride": false,
       "id": 20,
@@ -827,7 +995,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 20
+        "y": 29
       },
       "hideTimeOverride": false,
       "id": 26,
@@ -925,7 +1093,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 35
       },
       "id": 32,
       "legend": {
@@ -1018,7 +1186,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "id": 30,
       "legend": {


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-8515

Verification:

https://grafana-bbb.apps.aliok-6268.openshiftworkshop.com/d/S8luLn9iz2/data-sync-test-2?panelId=39&orgId=1&from=1550581722321&to=1550582022321

See the "Client" row in there.

Notes:
* Even though `count( count by (client_id) (clients) )` aggregation shows the number of unique clients, it shows it for the time slices. That means, we can use that to show "number of unique clients over time" line graph. But we can't do like "number of total unique users in the selected time range in Grafana". I couldn't figure it out.